### PR TITLE
Reference correct error class for `KeyAlreadyExistsError`

### DIFF
--- a/lib/stasche/store/redis.rb
+++ b/lib/stasche/store/redis.rb
@@ -15,7 +15,7 @@ module Stasche
       def set(key, value, ttl: 3600, force: false)
         ok = cache.set(key, value, ex: ttl, nx: !force)
 
-        fail KeyAlreadyExists, key unless ok
+        fail KeyAlreadyExistsError, key unless ok
 
         ok
       end


### PR DESCRIPTION
Honestly only noticed because code coverage was sub-:100:.
