### PR TITLE
Force values to be JSON objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,4 @@ Style/SignalException:
   EnforcedStyle: semantic
 
 Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
+  EnforcedStyle: space

--- a/lib/stasche/client.rb
+++ b/lib/stasche/client.rb
@@ -25,12 +25,12 @@ module Stasche
     def get(key, expire: false)
       value = store.get("#{namespace}:#{key}")
       del(key) if expire
-      value.nil? || value.empty? ? nil : JSON.load(value)
+      value.nil? || value.empty? ? nil : JSON.load(value)['value']
     end
 
     def set(values, options = {})
       last_value = values.inject(nil) do |_, (key, value)|
-        json = value.to_json
+        json = { value: value }.to_json
         store.set("#{namespace}:#{key}", json, options)
         key
       end

--- a/lib/stasche/version.rb
+++ b/lib/stasche/version.rb
@@ -1,3 +1,3 @@
 module Stasche
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end


### PR DESCRIPTION
The `json` gem parses non-JSON strings differently between versions
1.8.3 and 2.1.0 on OSX.  Parsing `"\"foo\""` yields `"foo"` in 1.8.3 and an
exception in 2.1.0.  Embedding the value in a Hash and calling to_json
on the Hash guarantees parsing will succeed regardless of version.