### PR TITLE
Add new utilities(rpc, call)

### DIFF
--- a/lib/stasche/store/redis.rb
+++ b/lib/stasche/store/redis.rb
@@ -28,6 +28,14 @@ module Stasche
         cache.keys(pattern)
       end
 
+      def lpop(key)
+        cache.lpop(key)
+      end
+
+      def lpush(key, value)
+        cache.lpush(key, value)
+      end
+
       private
 
       def cache

--- a/lib/stasche/version.rb
+++ b/lib/stasche/version.rb
@@ -1,3 +1,3 @@
 module Stasche
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end

--- a/spec/stasche/client_spec.rb
+++ b/spec/stasche/client_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Stasche::Client do
   context 'when passed a configuration block' do
-    let(:client) do described_class.new do |config|
+    let(:client) do
+      described_class.new do |config|
         config.namespace = 'test'
       end
     end
@@ -171,9 +172,16 @@ RSpec.describe Stasche::Client do
 
     after { Thread.kill(rpc) }
 
-    it 'adds two numbers' do
-      expect(client.call(:add, 1, 2)).to eq(3)
+    context 'when used correctly' do
+      it 'adds two numbers' do
+        expect(client.call(:add, 1, 2)).to eq(3)
+      end
+    end
+
+    context 'when an exception raised' do
+      it 'raises an error' do
+        expect { client.call(:add, 'str', 1) }.to raise_error(Exception)
+      end
     end
   end
-
 end


### PR DESCRIPTION
Implement debug utilities to communicate between apps. Used for NetSuite backfills. Useful for backfills across multiple applications.

Example:

```ruby
# In Checkr
Stasche.rpc(:resolve_company_name) { |name| Account.find_by(uri_name: name)&.resource_id }

# In Billing
invoice.external_id = Stasche.call(:resolve_company_name, invoice.company_name)
```

This implements a way to communicate between apps even if there aren't any APIs available. It's a thin abstraction around Stasche, not intended to use for any production purposes.