### PR TITLE
Override client inspect to hide secrets

### DIFF
--- a/lib/stasche/client.rb
+++ b/lib/stasche/client.rb
@@ -77,6 +77,11 @@ module Stasche
       store.del("#{namespace}:#{key}")
     end
 
+    def inspect
+      address = "0x#{(object_id << 1).to_s(16).rjust(14, '0')}"
+      "\#<#{self.class}:#{address}>"
+    end
+
     private
 
     def encrypt(value)

--- a/lib/stasche/version.rb
+++ b/lib/stasche/version.rb
@@ -1,3 +1,3 @@
 module Stasche
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.3.2'.freeze
 end

--- a/spec/stasche/client_spec.rb
+++ b/spec/stasche/client_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Stasche::Client do
     end
   end
 
+  describe '#inspect' do
+    let(:encryption_key) { 'super_secret' }
+    let(:client) do
+      described_class.new(encrypter: Encrypter, encryption_key: encryption_key)
+    end
+
+    it 'returns a string which does not contain the encryption key' do
+      expect(client.inspect).not_to include(encryption_key)
+    end
+  end
+
   describe '#get' do
     let(:client) do
       described_class.new(encrypter: Encrypter, encryption_key: 'foo')

--- a/stasche.gemspec
+++ b/stasche.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/stasche/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.name        = 'stasche'
   gem.version     = Stasche::VERSION
-  gem.authors     = ['Jon Whiteaker', 'Eric Psalmond']
+  gem.authors     = ['Jon Whiteaker', 'Eric Psalmond', 'Bobby Stratton']
   gem.email       = %w[eng@checkr.com]
   gem.summary     = 'Stash + Cache = Profit'
   gem.description = 'Utility to enable sharing objects across remote sessions.'


### PR DESCRIPTION
The client object has `@encryption_key` as an instance variable, which is displayed in the console when inspecting the object.