### PR TITLE
Upgrade Rubocop dependency to `~> 0.49`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.37.0', require: false
+  gem 'rubocop', '~> 0.49', require: false
 end


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418