### PR TITLE
Fix 'set' call's options for compatibility with ruby 2.7+

### DIFF
--- a/lib/stasche/client.rb
+++ b/lib/stasche/client.rb
@@ -35,7 +35,7 @@ module Stasche
       last_value = values.inject(nil) do |_, (key, value)|
         json = { value: value }.to_json
         encrypted_json = encrypt(json)
-        store.set("#{namespace}:#{key}", encrypted_json, options)
+        store.set("#{namespace}:#{key}", encrypted_json, **options)
         key
       end
 

--- a/lib/stasche/version.rb
+++ b/lib/stasche/version.rb
@@ -1,3 +1,3 @@
 module Stasche
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.3.4'.freeze
 end


### PR DESCRIPTION
minimal example of an incompatibility in the `client#set` method: 
```
def aFunc(arg1, arg2, third:false)
  puts arg1, arg2, third
end

def bFunc(kvs, options = {})
  kvs.inject(nil) do |_, (key, value)|
    aFunc(key, value, options)
  end
end

  
bFunc({'123' => '456'})
```

on ruby 2.6 this is fine, on ruby 3.0.4 it errors like this: 
```
script.rb:2:in `aFunc': wrong number of arguments (given 3, expected 2) (ArgumentError)
        from script.rb:8:in `block in bFunc'
        from script.rb:7:in `each'
        from script.rb:7:in `inject'
        from script.rb:7:in `bFunc'
        from script.rb:13:in `<main>'
```

the `**options` looks like it works on 2.6 as well, so backwards compatible.